### PR TITLE
Track version; add makefile target for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 VERSION = 1.0.0
 
+release:
+	@git rev-parse v$(VERSION) &> /dev/null; \
+	if [ "$$?" -eq 0 ]; then \
+		echo "Error: Release $(VERSION) already exists."; \
+		echo "Bump version in the Makefile before releasing."; \
+		exit 1; \
+	fi; \
+	if $$(git status --porcelain | grep -q "M Makefile"); then \
+		echo "Error: Refusing to release with uncommitted changes to Makefile."; \
+		echo "Commit or discard these changes before releasing."; \
+		exit 1; \
+	fi; \
+	git tag -a -m "Release $(VERSION)" v$(VERSION); \
+	printf "\nNew release $(VERSION) tagged!\n\n"
+
 tag-production:
 	@TODAY=`date "+%F-%H%M%S"`; \
 	git rev-parse production-$$TODAY &> /dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = 1.0.0
+
 tag-production:
 	@TODAY=`date "+%F-%H%M%S"`; \
 	git rev-parse production-$$TODAY &> /dev/null; \


### PR DESCRIPTION
To make the release process more formal, track the software version in the makefile and add a target to create annotated tags for new releases.

I'm keeping the existing 'tag-production' makefile target in case others want to use it. But it makes little sense to create tags of this nature within this git repo, since the tags do not always imply a proper software release.