### PR TITLE
Make Population view Clear Linux specific (for now)

### DIFF
--- a/shared/model.py
+++ b/shared/model.py
@@ -510,6 +510,7 @@ class Record(db.Model):
         q = db.session.query(Build.build, db.func.count(db.distinct(internal_expr)), db.func.count(db.distinct(external_expr)))
         q = q.join(Record).join(Classification)
         q = q.filter(Classification.classification=="org.clearlinux/heartbeat/ping")
+        q = q.filter(Record.os_name == 'clear-linux-os')
         q = q.group_by(Build.build)
 
         if most_recent:


### PR DESCRIPTION
I am currently seeing the Population view crash due to the failing
cast(Build.build, db.Integer) call in get_heartbeat_msgs(), so restrict
this query to records matching Clear Linux only for now; records from
Clear Linux must have an integer Build number, so the cast will succeed
for these records.

Also note that the Population view is most interesting when there are
systems running a wide range of build numbers for a particular OS. Since
Clear Linux releases two builds per day, the wide range tends to apply
especially for this distro, and restricting the view to be Clear-Linux
only (for now) seems a reasonable default.