### PR TITLE
stats view: sort classification/machine totals in descending order

### DIFF
--- a/shared/model.py
+++ b/shared/model.py
@@ -311,9 +311,10 @@ class Record(db.Model):
 
     @staticmethod
     def get_recordcnts_by_classification():
-        q = db.session.query(Classification.classification, db.func.count(Record.id))
+        q = db.session.query(Classification.classification, db.func.count(Record.id).label('total'))
         q = q.join(Record.classification)
         q = q.group_by(Classification.classification)
+        q = q.order_by(desc('total'))
         return q.all()
 
     @staticmethod
@@ -339,8 +340,10 @@ class Record(db.Model):
 
     @staticmethod
     def get_recordcnts_by_machine_type():
-        q = db.session.query(Record.machine, db.func.count(Record.id)).group_by(Record.machine).all()
-        return q
+        q = db.session.query(Record.machine, db.func.count(Record.id).label('total'))
+        q = q.group_by(Record.machine)
+        q = q.order_by(desc('total'))
+        return q.all()
 
     @staticmethod
     def get_recordcnts_by_severity():


### PR DESCRIPTION
Sorting the results in this way results in the larger slices of the pie
charts using the predefined color palette instead of the default gray.