### PR TITLE
Fix for multiple plugins selected

### DIFF
--- a/telemetryui/telemetryui/static/js/telemetryui.js
+++ b/telemetryui/telemetryui/static/js/telemetryui.js
@@ -34,7 +34,11 @@
 
     function initTabs(){
         if (window.location.pathname !== "/telemetryui/") {
-            var leading_path = window.location.pathname.split('/').slice(0,3).join('/');
+            var pathname = window.location.pathname;
+            var leading_path = pathname.split('/').slice(0,3).join('/');
+            if (pathname.search('\/plugins\/') > 0) {
+                leading_path = pathname.split('/').slice(0,4).join('/');
+            }
             jQuery("ul.nav.nav-tabs li").removeClass("active");
             jQuery('ul.nav.nav-tabs li a[href^="' + leading_path + '"]').parent().addClass("active");
         }


### PR DESCRIPTION
When clicking on a plugin tab all the view plugins tabs are selected.
This change fixes issue when selecting a tab by handling selection in
different ways when is a built in tab vs plugin tab.