### PR TITLE
Label and text setting simplification

### DIFF
--- a/telemetryui/telemetryui/__init__.py
+++ b/telemetryui/telemetryui/__init__.py
@@ -23,6 +23,7 @@ from .jinja_filters import (
     timesince,
     local_datetime_since,
     basename,
+    get_severity_label
     )
 import importlib
 
@@ -57,6 +58,7 @@ app.jinja_env.globals['url_for_other_page'] = url_for_other_page
 app.add_template_filter(timesince)
 app.add_template_filter(local_datetime_since)
 app.add_template_filter(basename)
+app.add_template_filter(get_severity_label)
 app.add_template_filter(_plugin_metadata())
 
 

--- a/telemetryui/telemetryui/jinja_filters.py
+++ b/telemetryui/telemetryui/jinja_filters.py
@@ -61,4 +61,12 @@ def basename(path):
 def plugin_metadata(name):
     return name.title()
 
+
+def get_severity_label(severity):
+    return {
+        2: ("info", "med",),
+        3: ("warning", "high",),
+        4: ("danger", "crit",)
+    }.get(severity, ("default", "low",))
+
 # vi: ts=4 et sw=4 sts=4

--- a/telemetryui/telemetryui/templates/records_template.html
+++ b/telemetryui/telemetryui/templates/records_template.html
@@ -41,20 +41,7 @@
                 {%- endif %}
                 <td><span data-toggle="tooltip" data-placement="top" title="{{ rec.machine_id }}"><div class="machine_id">{{ rec.machine_id }}</div></span></td>
                 <td>{{ rec.tsp_server | timesince }}</td>
-                {%- if rec.severity == 1 %}
-                {%- set label = "default" %}
-                {%- set text = "low" %}
-                {%- elif rec.severity == 2 %}
-                {%- set label = "info" %}
-                {%- set text = "med" %}
-                {%- elif rec.severity == 3 %}
-                {%- set label = "warning" %}
-                {%- set text = "high" %}
-                {%- elif rec.severity == 4 %}
-                {%- set label = "danger" %}
-                {%- set text = "crit" %}
-                {%- endif %}
-                <td><span class="label label-{{ label }}">{{ text }}</span></td>
+                <td><span class="label label-{{ (rec.severity | get_severity_label).0 }}">{{ (rec.severity | get_severity_label).1 }}</span></td>
                 <td class="ellipsize">{{ rec.classification.classification|replace("org.clearlinux/", "") }}</td>
                 <td>{{ rec.os_name }}</td>
                 <td>{{ rec.build.build }}</td>


### PR DESCRIPTION
Moving code in template to jinja filter to simplify html code. We should
try to keep control statements in HTML content as few as possible.

Signed-off-by: avjarami <alex.v.jaramillo@intel.com>