### PR TITLE
Fix for record table overflowing container

### DIFF
--- a/telemetryui/telemetryui/static/css/style.css
+++ b/telemetryui/telemetryui/static/css/style.css
@@ -2,10 +2,8 @@
 	overflow: hidden;
     	text-overflow: ellipsis;
 	white-space: nowrap;
-        max-width: 480px;
 	float:left;
 	color:blue;
-	width:95%;
 }
 
 .machine_id {
@@ -23,9 +21,8 @@
 }
 
 #more_button {
-    float: right;
     color: red;
-    width: 5%;
+    float: right;
 }
 
 #records_page_div{
@@ -80,4 +77,53 @@ div.series-legend {
     width: 30px;
     margin-right: 5px;
     background-color: #E0E0E0;
+}
+
+/* Records table */
+table.telem-records {
+    table-layout: fixed;
+}
+
+th.row-id {
+    width: 5%
+}
+
+th.row-source {
+    width: 5%;
+}
+
+th.row-machine-id {
+    width: 17%;
+}
+
+th.row-when {
+    width: 8%;
+}
+
+th.row-severity {
+    width: 7%;
+}
+
+th.row-class {
+    width: 15%;
+}
+
+th.row-os {
+    width: 8%;
+}
+
+th.row-version {
+    width: 5%;
+}
+
+th.row-payload {
+    width: 25%;
+}
+
+th.row-button {
+    width: 5%;
+}
+
+td.row-payload {
+    color: blue;
 }

--- a/telemetryui/telemetryui/templates/records_template.html
+++ b/telemetryui/telemetryui/templates/records_template.html
@@ -18,17 +18,18 @@
     {{ helpers.render_pagination(records) }}
 
     <h3>Records found: {{ records.total }}</h3>
-    <table class="table table-hover table-condensed text-nowrap">
+    <table class="table table-hover table-condensed text-nowrap telem-records">
         <thead>
-            <th>Id</th>
-            <th>Source</th>
-            <th>Machine ID</th>
-            <th>When</th>
-            <th>Severity</th>
-            <th class="ellipsize">Classification</th>
-            <th>OS</th>
-            <th>Ver</th>
-            <th>Payload</th>
+            <th class="row-id">Id</th>
+            <th class="row-source">Source</th>
+            <th class="row-machine-id">Machine ID</th>
+            <th class="row-when">When</th>
+            <th class="row-severity">Severity</th>
+            <th class="row-class ellipsize">Classification</th>
+            <th class="row-os">OS</th>
+            <th class="row-version">Ver</th>
+            <th class="row-payload ellipsize">Payload</th>
+            <th class="row-button"></th>
         </thead>
         <tbody>
         {% for rec in records.items %}
@@ -45,9 +46,9 @@
                 <td class="ellipsize">{{ rec.classification.classification|replace("org.clearlinux/", "") }}</td>
                 <td>{{ rec.os_name }}</td>
                 <td>{{ rec.build.build }}</td>
-                <td><div class="payload_container"><div class="payload">{{ rec.backtrace }}</div>
-                        <button id="more_button" type="button" data-toggle="modal" data-target="#myModal" data-whatever="{{ rec.backtrace }}">...</button>
-                    </div>
+                <td class="ellipsize row-payload">{{ rec.backtrace }}</td>
+                <td>
+                    <button id="more_button" type="button" data-toggle="modal" data-target="#myModal" data-whatever="{{ rec.backtrace }}">...</button>
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
When table overflows container the button to display the contents of the
payload are pushed behind browser slider to the right where it is no longer
visible. This change returns the table to the bounds of the container
making "more details" button always visible.

Signed-off-by: avjarami <alex.v.jaramillo@intel.com>