### PR TITLE
Plugable payload parsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ run-tests:
 	PYTHONPATH=/$(shell pwd)/collector python3 collector/collector/tests/api.py	
 	PYTHONPATH=/$(shell pwd)/collector python3 collector/collector/tests/purging.py
 	PYTHONPATH=/$(shell pwd)/collector python3 collector/collector/tests/validation.py
+	PYTHONPATH=/$(shell pwd)/collector python3 collector/collector/tests/parsers.py
 
 tag-production:
 	@TODAY=`date "+%F-%H%M%S"`; \

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ At minimum, make sure that your telemetrics-client configuration in
 `example.com`, the client config should contain `server=http://example.com/` or
 `server=http://example.com/v2/collector`.
 
+
+## `collector` plugable payload parsers
+
+By default `collector` will save the payload record from telemetry messages as is
+received, there are cases when is desirable to apply additional transformations to
+payload on selected classifications. This use case is covered by custom payload
+parsers/(or transformations). For more information on this feature read specific
+[documentation](/collector/collector/parsers/README.md)
+
 ## `telemetryui` views
 
 The `telemetryui` app is a web app that exposes several views to visualize the

--- a/collector/collector/config_local.py
+++ b/collector/collector/config_local.py
@@ -45,6 +45,8 @@ class Config(object):
             "org.clearlinux/hello/world": 1,
         }
     }
+    # Custom Payload transformations
+    # POST_PROCESSING_PARSERS = ["demo"]
 
 
 class Testing(Config):

--- a/collector/collector/lib/exceptions.py
+++ b/collector/collector/lib/exceptions.py
@@ -1,0 +1,6 @@
+
+
+class PlugablePayloadParserException(Exception):
+
+    def __init__(self, message):
+        self.__str__ = message

--- a/collector/collector/lib/parser.py
+++ b/collector/collector/lib/parser.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+try:
+    from uwsgidecorators import spool
+except ImportError:
+    def spool(f):
+        f.spool = f
+        return f
+
+# Alias for uwsgi spool feature. Using this feature to async data processing from
+# different probes.
+# Aliasing this feature will make it easier in the future to move to a different
+# product if scaling becomes a problem.
+parser_spooler = spool

--- a/collector/collector/parsers/README.md
+++ b/collector/collector/parsers/README.md
@@ -1,0 +1,68 @@
+## Plugable payload parsers
+
+### Overview
+
+A plugable parser is a python module that encapsulates a data transformation.
+This transformation is applied to telemetry message payload if the classification
+matches one of the classifications that the parser defines during plugin
+registration.
+
+Plugin registration occurs during collector initialization, to enable a plugin
+the plugin needs to be listed in the array ```POST_PROCESSING_PARSERS``` in
+collector configuration.
+
+For example to enable the ```demo``` parser plugin that comes with the telemetry
+backend we need to add a line like the following to collector configuration:
+
+```python
+
+class Config(object):
+
+    # ... some configuration values
+
+    POST_PROCESSING_PARSERS = ["demo"]
+
+    # ... more configuration values
+
+```
+
+
+### Plugable parser `installation`
+
+The plugable parser module needs to be located under parsers directory, see
+the following plugin parser source tree:
+
+```bash
+<telemetry-root>/collector/collector/
+                                    parsers/
+                                            <parser_name_dir>/
+                                                            __init__.py
+                                                            main.py
+```
+
+* ```<parser_name_dir>``` is the parser module name and should live under
+collector/parsers
+* ```main.py``` is the entry point for plugin registration.
+
+The parser entry point `must have` the following members:
+
+* An array called ```CLASSIFICATIONS``` with a list of message classifications. Any message
+that matches one of these classifications will be parsed by this plugin.
+
+* A function signature ```parse_payload(kwargs)```
+which is the transformation that will be applied to the payload.
+
+### Other considerations
+
+Plugable parsers are applied asynchronously and no major consideration is required for
+most use cases. When in doubt keep in mind the following:
+
+* Payload transformations are applied after the message record (including payload)
+is safely stored.
+* It is a correct assumption to think that the entire record can
+be queried from storage.
+* It is not possible to register multiple plugins for the same classification,
+the correct way to go about doing this is to encapsulate the multiple
+transformations in one plugin. This is by design, remember that transformations
+are applied asynchronously therefore a given plugin execution order is not
+guaranteed.

--- a/collector/collector/parsers/demo/main.py
+++ b/collector/collector/parsers/demo/main.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import time
+import base64
+from collector.lib.parser import parser_spooler
+
+CLASSIFICATIONS = ['org.clearlinux/telemetry/b64payload']
+
+
+@parser_spooler
+def parse_payload(**kwargs):
+    """
+    :param kwargs: classification=<value>,
+                   record_id=<value>,
+                   payload=<value>
+    :return: None
+    """
+    print("Processing data")
+    print(base64.b64decode(kwargs.get('payload')))
+    print("Data processed")

--- a/collector/collector/parsers/demo/models.py
+++ b/collector/collector/parsers/demo/models.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collector.models import db
+
+class Message(db.Model):
+    __tablename__ = 'demo_message'
+    record_id = db.Column(db.Integer, db.ForeignKey('records.id'))
+    payload = buildstamp = db.Column(db.String, default='')
+
+    def __init__(self, **kwargs):
+        self.record_id = kwargs.get('record_id', None)
+        self.payload = kwargs.get('payload', None)

--- a/collector/collector/report_handler.py
+++ b/collector/collector/report_handler.py
@@ -17,9 +17,11 @@
 import re
 import time
 import datetime
+import importlib
 from flask import request
 from flask import jsonify
 from flask import redirect
+from .lib.exceptions import PlugablePayloadParserException
 from .lib.validation import (
     validate_header,
     validate_query,
@@ -42,6 +44,11 @@ ts_v3_regex = re.compile("^[0-9]+$")
 max_payload_len_inline = 30 * 1024	 # 30k
 max_payload_len = 300 * 1024		 # 300k
 MAX_INTERVAL_SEC = 24 * 60 * 60 * 30    # 30 days in seconds
+
+
+# This variable is loaded during app initialization from
+# values on config.POST_PROCESSING_PARSERS
+POST_PROCESSING_PARSERS = {}
 
 
 @app.errorhandler(InvalidUsage)
@@ -186,9 +193,15 @@ def collector_post_handler():
                            record_format_version, ts_capture, ts_reception, payload_format_version, os_name,
                            board_name, bios_version, cpu_model, event_id, external, payload)
 
+    # TODO: This should become a plugable parser
     if is_crash_classification(classification):
         # must pass args as bytes to uwsgi under Python 3
         process_guilties(klass=classification.encode(), id=str(db_rec.id).encode())
+
+    if classification in POST_PROCESSING_PARSERS.keys():
+        POST_PROCESSING_PARSERS[classification](classification=classification.encode(),
+                                                record_id=str(db_rec.id).encode(),
+                                                payload=payload.encode())
 
     resp = jsonify(db_rec.to_dict())
     resp.status_code = 201
@@ -285,5 +298,40 @@ def records_api_handler():
     """
     return get_records_api_handler()
 
+
+def verify_parser_module(parser_module):
+
+    if getattr(parser_module, 'CLASSIFICATIONS', None) is None:
+        raise PlugablePayloadParserException('Parser {} should have a CLASSIFICATIONS field')
+
+    if getattr(parser_module, 'parse_payload', None) is None:
+        raise PlugablePayloadParserException('Parser {} should have a parse_payload method')
+
+
+def load_parser(parser_name):
+    global POST_PROCESSING_PARSERS
+
+    try:
+        parser_module = importlib.import_module("collector.parsers.{}.main".format(parser_name))
+        verify_parser_module(parser_module)
+        for parser_classification in parser_module.CLASSIFICATIONS:
+            if parser_classification in POST_PROCESSING_PARSERS.keys():
+                raise PlugablePayloadParserException("Parser plugin for class"
+                                                     " {} is already registered".format(parser_classification))
+            POST_PROCESSING_PARSERS[parser_classification] = parser_module.parse_payload
+            app.logger.info(" * Parser: {} registered for class: {}".format(parser_name, parser_classification))
+    except PlugablePayloadParserException as e:
+        print(e.str())
+    except ImportError as ie:
+        print(ie)
+
+
+def load_parsers():
+    pp_parsers = app.config.get('POST_PROCESSING_PARSERS', [])
+    for pp_parser in pp_parsers:
+        load_parser(pp_parser)
+
+
+load_parsers()
 
 # vi: ts=4 et sw=4 sts=4

--- a/collector/collector/tests/parsers.py
+++ b/collector/collector/tests/parsers.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import base64
+import unittest
+from collector import app
+from collector.parsers.demo import main
+from collector.report_handler import load_parsers
+from collector.tests.testcase import (
+    RecordTestCases,
+    get_record_v3,)
+
+
+class TestCasesParserPlugin(RecordTestCases):
+    """
+        Load parsers programmatically for test
+    """
+    def setUp(self):
+        RecordTestCases.setUp(self)
+        app.config['POST_PROCESSING_PARSERS'] = ["demo"]
+        load_parsers()
+
+
+class TestParserPlugin(TestCasesParserPlugin):
+    """
+        Simple test to make sure that plugins parsers are working
+    """
+    def test_record_created(self):
+        headers = get_record_v3()
+        data = b'Hello World'
+        _data = base64.b64encode(data)
+        headers['classification'] = main.CLASSIFICATIONS
+        response = self.client.post('/', headers=headers, data=_data)
+        self.assertTrue(response.status_code == 201, response.data.decode('utf-8'))
+
+
+if __name__ == '__main__' and __package__ is None:
+    from os import sys, path
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+    unittest.main()


### PR DESCRIPTION
This change adds the option to have custom parsers to post process
message payload. Before this change the payload was stored as it was
received(1).

With this change payloads can be postprocessed after the message is
safely stored. The transformation to apply to a payload is defined
by the classification of the record. More details can be found at
[documentation](collector/collector/parsers/README.md).

(1) There is an exception for guilties (see at shared/guilty.py)

Signed-off-by: avjarami <alex.v.jaramillo@intel.com>