### PR TITLE
Improvements to vassals ini files

### DIFF
--- a/scripts/collector_uwsgi.ini
+++ b/scripts/collector_uwsgi.ini
@@ -3,17 +3,15 @@
 chdir = @@install_path@@collector/
 
 #python module to import
-app = collector
-module = %(app)
+virtualenv = @@install_path@@venv/
+module = collector:app
+plugins = python3
 
 #socket file's location
 socket = @@install_path@@collector/%n.sock
 
 #permissions for the socket file
 chmod-socket    = 644
-
-#the variable that holds a flask application inside the module imported at line #6
-callable = app
 
 processes = 4
 

--- a/scripts/telemetryui_uwsgi.ini
+++ b/scripts/telemetryui_uwsgi.ini
@@ -3,17 +3,15 @@
 chdir = @@install_path@@telemetryui/
 
 #python module to import
-app = telemetryui
-module = %(app)
+virtualenv = @@install_path@@venv/
+module = telemetryui:app
+plugins = python3
 
 #socket file's location
 socket = @@install_path@@telemetryui/%n.sock
 
 #permissions for the socket file
 chmod-socket    = 644
-
-#the variable that holds a flask application inside the module imported at line #6
-callable = app
 
 processes = 4
 

--- a/scripts/uwsgi.service
+++ b/scripts/uwsgi.service
@@ -6,8 +6,7 @@ After=network.target
 User=@@nginx_user@@
 Group=@@nginx_group@@
 Environment="LOGTO=/var/log/uwsgi/emperor.log"
-Environment="PATH=@@install_path@@venv/bin/uwsgi"
-ExecStart=@@install_path@@venv/bin/uwsgi --master --emperor /etc/uwsgi/vassals --die-on-term --uid @@nginx_user@@ --gid @@nginx_group@@ --logto ${LOGTO}
+ExecStart=@@uwsgi_bin_path@@ --master --emperor /etc/uwsgi/vassals --die-on-term --uid @@nginx_user@@ --gid @@nginx_group@@ --logto ${LOGTO}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Using system provided uwsgi and reworking application definition
section for telemetry and collector vassals.
    
clr-on-clr bundle no longer needed for Clear Linux.
    
Running 'apt-get update' and 'yum check-update' before installing
packages.

Signed-off-by: avjarami <alex.v.jaramillo@intel.com>