### PR TITLE
Bumping Flask version to 0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==0.9.5
 click==6.7
-Flask==0.12.2
+Flask==0.12.3
 Flask-Migrate==2.1.0
 Flask-SQLAlchemy==2.2
 Flask-WTF==0.14.2

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -221,7 +221,7 @@ _write_requirements() {
     cat > $1 << EOF
 alembic==0.9.5
 click==6.7
-Flask==0.12.2
+Flask==0.12.3
 Flask-Migrate==2.1.0
 Flask-SQLAlchemy==2.2
 Flask-WTF==0.14.2


### PR DESCRIPTION
Updating required flask version to 0.12.3 that has a patch that fixes
CVE-2018-1000656. App is know to work with Flask 0.12.3

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>