### PR TITLE
Adding uWSGI dependencies

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -246,9 +246,9 @@ _install_pip_pkgs() {
   sudo rm -f "$log"
   if [ $DISTRO == "clr" ]; then
     # the latest psycopg2 binary package is incompatible with the glibc 2.26 on Clear Linux
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install --no-binary psycopg2 -r $reqs"
+    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install --no-binary psycopg2 -r $reqs uwsgidecorators"
   else
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs"
+    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs uwsgi uwsgidecorators"
   fi
 }
 


### PR DESCRIPTION
Spool processing of crashes requires uwsgidecorators module, in clear
linux the module uwsgi is provided by a bundle but not the decorator.
This change adds installation of uwsgidecorators module to section where
requirements are installed based on the distro.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>