### PR TITLE
RFC Updates

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,9 +16,9 @@
 #
 
 REMOTE_APP_DIR="/var/www/telemetry"
-DEBIAN_PKGS="build-essential python3 python3-dev python3-pip virtualenv libpq-dev nginx git uwsgi uwsgi-plugin-python3"
-REDHAT_PKGS="gcc gcc-c++ make python34 python34-devel python34-pip python34-virtualenv postgresql-devel postgresql-server postgresql-contrib nginx git policycoreutils-python uwsgi uwsgi-plugin-python3"
-CLR_BUNDLES="application-server database-basic database-basic-dev python-basic os-core-dev web-server-basic"
+DEBIAN_PKGS="build-essential python3 python3-dev python3-pip virtualenv libpq-dev nginx git uwsgi uwsgi-plugin-python3 redis"
+REDHAT_PKGS="gcc gcc-c++ make python34 python34-devel python34-pip python34-virtualenv postgresql-devel postgresql-server postgresql-contrib nginx git policycoreutils-python uwsgi uwsgi-plugin-python3 redis"
+CLR_BUNDLES="application-server database-basic database-basic-dev python-basic os-core-dev web-server-basic redis-native"
 DB_PASSWORD=""
 NGINX_USER=""
 NGINX_GROUP=""
@@ -176,6 +176,7 @@ do_restart() {
   sudo systemctl daemon-reload
   sudo systemctl restart nginx
   sudo systemctl restart uwsgi
+  sudo systemctl restart redis
 }
 
 set_proxy() {
@@ -232,6 +233,7 @@ MarkupSafe==1.0
 psycopg2==2.7.6
 python-dateutil==2.6.1
 python-editor==1.0.3
+redis==3.1.0
 six==1.10.0
 SQLAlchemy==1.1.13
 Werkzeug==0.12.2
@@ -513,6 +515,9 @@ _deploy() {
   sudo ln -sf $REMOTE_APP_DIR/telemetryui/telemetryui_uwsgi.ini /etc/uwsgi/vassals/
   sudo ln -sf $REMOTE_APP_DIR/collector/collector_uwsgi.ini /etc/uwsgi/vassals/
   sudo systemctl enable uwsgi
+
+  # Enable redis
+  sudo systemctl enable redis
 
   # Cert configuration
   if [ ! -f /etc/nginx/ssl/telemetry.cert.pem ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -229,7 +229,7 @@ itsdangerous==0.24
 Jinja2==2.9.6
 Mako==1.0.7
 MarkupSafe==1.0
-psycopg2==2.7.3
+psycopg2==2.7.6
 python-dateutil==2.6.1
 python-editor==1.0.3
 six==1.10.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -245,12 +245,7 @@ _install_pip_pkgs() {
   local log=$REMOTE_APP_DIR/install.log
   local reqs=$1
   sudo rm -f "$log"
-  if [ $DISTRO == "clr" ]; then
-    # the latest psycopg2 binary package is incompatible with the glibc 2.26 on Clear Linux
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install --no-binary psycopg2 -r $reqs uwsgidecorators"
-  else
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs uwsgi uwsgidecorators"
-  fi
+  sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs uwsgi uwsgidecorators"
 }
 
 _install_virtual_env() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,7 +27,6 @@ COLLECTOR_INI="collector_uwsgi.ini"
 TELEMETRYUI_INI="telemetryui_uwsgi.ini"
 SPOOL_DIR="uwsgi-spool"
 APT_GET_INSTALL="DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::=\"--force-confnew\""
-APT_GET_REMOVE="DEBIAN_FRONTEND=noninteractive apt-get remove -y -o Dpkg::=\"--force-confnew\""
 YUM_INSTALL="yum install -y"
 
 usage() {
@@ -638,13 +637,12 @@ do_resetdb() {
 }
 
 _uninstall_ubuntu_pkgs() {
-  sudo $APT_GET_REMOVE postgresql postgresql-contrib
   sudo rm -rv $REMOTE_APP_DIR
   sudo rm -rfv /etc/init/uwsgi.conf
   sudo rm -rfv /lib/systemd/system/uwsgi.service
   sudo rm -rv /etc/uwsgi/vassals
   sudo bash -c "yes | pip3 uninstall uwsgitop"
-  sudo $APT_GET_REMOVE $DEBIAN_PKGS
+  echo "The following packages required for the telemetryui may be removed at your discretion: $DEBIAN_PKGS"
 }
 
 do_uninstall() {

--- a/scripts/deployui.sh
+++ b/scripts/deployui.sh
@@ -26,7 +26,6 @@ REPO_NAME="telemetrics-backend"
 TELEMETRYUI_INI="telemetryui_uwsgi.ini"
 SPOOL_DIR="uwsgi-spool"
 APT_GET_INSTALL="DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::=\"--force-confnew\""
-APT_GET_REMOVE="DEBIAN_FRONTEND=noninteractive apt-get remove -y -o Dpkg::=\"--force-confnew\""
 YUM_INSTALL="yum install -y"
 
 usage() {
@@ -615,13 +614,12 @@ do_resetdb() {
 }
 
 _uninstall_ubuntu_pkgs() {
-  sudo $APT_GET_REMOVE postgresql postgresql-contrib
   sudo rm -rv $REMOTE_APP_DIR
   sudo rm -rfv /etc/init/uwsgi.conf
   sudo rm -rfv /lib/systemd/system/uwsgi.service
   sudo rm -rv /etc/uwsgi/vassals
   sudo bash -c "yes | pip3 uninstall uwsgitop"
-  sudo $APT_GET_REMOVE $DEBIAN_PKGS
+  echo "The following packages required for the telemetryui may be removed at your discretion: $DEBIAN_PKGS"
 }
 
 do_uninstall() {

--- a/scripts/deployui.sh
+++ b/scripts/deployui.sh
@@ -228,7 +228,7 @@ itsdangerous==0.24
 Jinja2==2.9.6
 Mako==1.0.7
 MarkupSafe==1.0
-psycopg2==2.7.3
+psycopg2==2.7.6
 python-dateutil==2.6.1
 python-editor==1.0.3
 six==1.10.0

--- a/scripts/deployui.sh
+++ b/scripts/deployui.sh
@@ -244,12 +244,7 @@ _install_pip_pkgs() {
   local log=$REMOTE_APP_DIR/install.log
   local reqs=$1
   sudo rm -f "$log"
-  if [ $DISTRO == "clr" ]; then
-    # the latest psycopg2 binary package is incompatible with the glibc 2.26 on Clear Linux
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install --no-binary psycopg2 -r $reqs"
-  else
-    sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs"
-  fi
+  sudo bash -c "https_proxy=$https_proxy source venv/bin/activate && https_proxy=$https_proxy pip3 --log $log install -r $reqs"
 }
 
 _install_virtual_env() {

--- a/scripts/deployui.sh
+++ b/scripts/deployui.sh
@@ -16,9 +16,9 @@
 #
 
 REMOTE_APP_DIR="/var/www/telemetry"
-DEBIAN_PKGS="build-essential python3 python3-dev python3-pip virtualenv libpq-dev nginx git uwsgi uwsgi-plugin-python3"
-REDHAT_PKGS="gcc gcc-c++ make python34 python34-devel python34-pip python34-virtualenv postgresql-devel postgresql-server postgresql-contrib nginx git policycoreutils-python uwsgi uwsgi-plugin-python3"
-CLR_BUNDLES="application-server database-basic database-basic-dev python-basic os-core-dev web-server-basic"
+DEBIAN_PKGS="build-essential python3 python3-dev python3-pip virtualenv libpq-dev nginx git uwsgi uwsgi-plugin-python3 redis"
+REDHAT_PKGS="gcc gcc-c++ make python34 python34-devel python34-pip python34-virtualenv postgresql-devel postgresql-server postgresql-contrib nginx git policycoreutils-python uwsgi uwsgi-plugin-python3 redis"
+CLR_BUNDLES="application-server database-basic database-basic-dev python-basic os-core-dev web-server-basic redis-native"
 DB_PASSWORD=""
 NGINX_USER=""
 NGINX_GROUP=""
@@ -175,6 +175,7 @@ do_restart() {
   sudo systemctl daemon-reload
   sudo systemctl restart nginx
   sudo systemctl restart uwsgi
+  sudo systemctl restart redis
 }
 
 set_proxy() {
@@ -231,6 +232,7 @@ MarkupSafe==1.0
 psycopg2==2.7.6
 python-dateutil==2.6.1
 python-editor==1.0.3
+redis==3.1.0
 six==1.10.0
 SQLAlchemy==1.1.13
 Werkzeug==0.12.2
@@ -498,6 +500,9 @@ _deploy() {
   sudo mkdir -pv /etc/uwsgi/vassals
   sudo ln -sf $REMOTE_APP_DIR/telemetryui/telemetryui_uwsgi.ini /etc/uwsgi/vassals/
   sudo systemctl enable uwsgi
+
+  # Enable redis
+  sudo systemctl enable redis
 
   # Cert configuration
   if [ ! -f /etc/nginx/ssl/telemetry.cert.pem ]; then

--- a/telemetryui/telemetryui/model.py
+++ b/telemetryui/telemetryui/model.py
@@ -506,7 +506,7 @@ class Record(db.Model):
 
         # query for records created in that last 2 weeks
         q = q.filter(Record.timestamp_client > time_2_weeks_ago)
-        return q
+        return q.all()
 
     @staticmethod
     def get_swupd_msgs(most_recent=None):


### PR DESCRIPTION
Several updates for the backend.

Removed some of the uninstall functionality. Removing packages was causing breakage, see issue #56. This was the primary culprit, but maybe we should remove more of it? The pip3 uninstall command might also should be removed, for example.

Updated psycopg2, as that version was not working on either Ubuntu 18 or new versions of Clear. Have not tested on Ubuntu 16, so might not be safe there.

Added caching! This massively improves performance of the UI. In some cases the gains were around two orders of magnitude, in others a mere 200%ish.

Updated installation scripts for new requirements. Clear Linux doesn't currently have a redis service file, which will need to be fixed for it to work properly there.